### PR TITLE
#5 Consolidate and generalise EDTF date fields for works and creators

### DIFF
--- a/glamkit_collections/contrib/work_creator/admin.py
+++ b/glamkit_collections/contrib/work_creator/admin.py
@@ -113,16 +113,16 @@ class CreatorChildAdmin(
         ICEkitContentsAdmin.inlines
 
     readonly_fields = (
-        'birth_date_earliest',
-        'birth_date_latest',
-        'birth_date_sort_ascending',
-        'birth_date_sort_descending',
-        'birth_date_edtf',
-        'death_date_earliest',
-        'death_date_latest',
-        'death_date_sort_ascending',
-        'death_date_sort_descending',
-        'death_date_edtf',
+        'start_date_earliest',
+        'start_date_latest',
+        'start_date_sort_ascending',
+        'start_date_sort_descending',
+        'start_date_edtf',
+        'end_date_earliest',
+        'end_date_latest',
+        'end_date_sort_ascending',
+        'end_date_sort_descending',
+        'end_date_edtf',
     )
 
     NAME_FIELDSET =  ('Name', {
@@ -136,24 +136,24 @@ class CreatorChildAdmin(
     DATE_FIELDSETS = (
         ("Dates", {
             'fields': (
-                ('birth_date_display',
-                'death_date_display',),
+                ('start_date_display',
+                 'end_date_display',),
             ),
         }),
         ("Advanced date controls", {
             'classes': ('collapse',),
             'fields': (
-                ('birth_date_earliest',
-                'birth_date_latest',),
-                ('birth_date_sort_ascending',
-                'birth_date_sort_descending',),
-                'birth_date_edtf',
+                ('start_date_earliest',
+                 'start_date_latest',),
+                ('start_date_sort_ascending',
+                 'start_date_sort_descending',),
+                'start_date_edtf',
 
-                ('death_date_earliest',
-                'death_date_latest',),
-                ('death_date_sort_ascending',
-                'death_date_sort_descending',),
-                'death_date_edtf',
+                ('end_date_earliest',
+                 'end_date_latest',),
+                ('end_date_sort_ascending',
+                 'end_date_sort_descending',),
+                'end_date_edtf',
             ),
         }),
     )
@@ -192,11 +192,11 @@ class WorkChildAdmin(
     exclude = ('layout', 'alt_slug',)
     prepopulated_fields = {"slug": ("accession_number", "title",)}
     readonly_fields = (
-        "date_edtf",
-        'date_earliest',
-        'date_latest',
-        'date_sort_ascending',
-        'date_sort_descending',
+        "creation_date_edtf",
+        'creation_date_earliest',
+        'creation_date_latest',
+        'creation_date_sort_ascending',
+        'creation_date_sort_descending',
     )
 
     inlines = [WorkOriginsInline, WorkCreatorsInlineForWorks, WorkImageInline] + \
@@ -205,17 +205,17 @@ class WorkChildAdmin(
     DATE_FIELDSETS = (
         ("Date", {
             'fields': (
-                'date_display',
+                'creation_date_display',
             ),
         }),
         ("Advanced date controls", {
             'classes': ('collapse',),
             'fields': (
-                ('date_earliest',
-                 'date_latest',),
-                ('date_sort_ascending',
-                 'date_sort_descending',),
-                'date_edtf',
+                ('creation_date_earliest',
+                 'creation_date_latest',),
+                ('creation_date_sort_ascending',
+                 'creation_date_sort_descending',),
+                'creation_date_edtf',
             ),
         }),
 

--- a/glamkit_collections/contrib/work_creator/api_serializers.py
+++ b/glamkit_collections/contrib/work_creator/api_serializers.py
@@ -1,13 +1,10 @@
-from django.apps import apps
-
 from rest_framework import serializers
 from rest_framework.settings import api_settings
 from rest_framework.validators import UniqueTogetherValidator
 from drf_queryfields import QueryFieldsMixin
 
-from icekit.api.base_serializers import ModelSubSerializer, \
-    PolymorphicHyperlinkedModelSerializer, WritableSerializerHelperMixin, \
-    WritableRelatedFieldSettings
+from icekit.api.base_serializers import WritableSerializerHelperMixin, \
+    PolymorphicHyperlinkedModelSerializer, WritableRelatedFieldSettings
 from icekit.api.images.serializers import RelatedImageSerializer
 
 from .models import WorkBase, CreatorBase, WorkCreator as WorkCreatorModel, \
@@ -84,23 +81,9 @@ class CreatorSummary(PolymorphicHyperlinkedModelSerializer):
         }
 
 
-class WorkDate(ModelSubSerializer):
-    class Meta:
-        model = WorkBase
-        source_prefix = 'date_'
-        fields = (
-            'date_display',
-            'date_edtf',
-        )
-
-
 class WorkSummary(WritableSerializerHelperMixin,
                   PolymorphicHyperlinkedModelSerializer):
     """ Minimal information about a work """
-    date = WorkDate(
-        required=False,
-        read_only=True,
-    )
 
     def get_child_view_name_data(self):
         from .plugins.game import api as game_api
@@ -118,7 +101,8 @@ class WorkSummary(WritableSerializerHelperMixin,
             api_settings.URL_FIELD_NAME,
             'id',
             'title',
-            'date',
+            'creation_date_display',
+            'creation_date_edtf',
         )
         extra_kwargs = {
             'id': {
@@ -239,6 +223,10 @@ class Creator(BaseCollectionModelSerializerMixin,
             'name_sort',
             'website',
             'wikipedia_link',
+            'start_date_display',
+            'start_date_edtf',
+            'end_date_display',
+            'end_date_edtf',
             # Metadata fields
             'id',
             'external_ref',
@@ -325,9 +313,6 @@ class Work(BaseCollectionModelSerializerMixin,
         many=True,
         read_only=True,
     )
-    date = WorkDate(
-        required=False,
-    )
     origin = WorkOrigin(
         source="workorigin_set",
         many=True,
@@ -341,8 +326,6 @@ class Work(BaseCollectionModelSerializerMixin,
             'creators',
             'images',
             'origin',
-            # Sub-resources
-            'date',
             # Fields
             api_settings.URL_FIELD_NAME,
             'publishing_is_draft',
@@ -353,6 +336,8 @@ class Work(BaseCollectionModelSerializerMixin,
             'department',
             'credit_line',
             'accession_number',
+            'creation_date_display',
+            'creation_date_edtf',
             # Metadata fields
             'id',
             'external_ref',

--- a/glamkit_collections/contrib/work_creator/migrations/0031_auto_20170606_1126.py
+++ b/glamkit_collections/contrib/work_creator/migrations/0031_auto_20170606_1126.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import edtf.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gk_collections_work_creator', '0030_auto_20170523_1243'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='workbase',
+            old_name='date_display',
+            new_name='creation_date_display',
+        ),
+        migrations.RenameField(
+            model_name='workbase',
+            old_name='date_earliest',
+            new_name='creation_date_earliest',
+        ),
+        migrations.RenameField(
+            model_name='workbase',
+            old_name='date_latest',
+            new_name='creation_date_latest',
+        ),
+        migrations.RenameField(
+            model_name='workbase',
+            old_name='date_sort_ascending',
+            new_name='creation_date_sort_ascending',
+        ),
+        migrations.RenameField(
+            model_name='workbase',
+            old_name='date_sort_descending',
+            new_name='creation_date_sort_descending',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='birth_date_display',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='birth_date_earliest',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='birth_date_edtf',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='birth_date_latest',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='birth_date_sort_ascending',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='birth_date_sort_descending',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='death_date_display',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='death_date_earliest',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='death_date_edtf',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='death_date_latest',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='death_date_sort_ascending',
+        ),
+        migrations.RemoveField(
+            model_name='creatorbase',
+            name='death_date_sort_descending',
+        ),
+        migrations.RemoveField(
+            model_name='workbase',
+            name='date_edtf',
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='end_date_display',
+            field=models.CharField(max_length=255, verbose_name=b'Date of death/closure (display)', blank=True, help_text=b'Displays date as formatted for display, rather than sorting.'),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='end_date_earliest',
+            field=models.DateField(blank=True, verbose_name=b'Earliest end date', null=True),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='end_date_edtf',
+            field=edtf.fields.EDTFField(lower_fuzzy_field=b'end_date_sort_ascending', upper_strict_field=b'end_date_latest', null=True, verbose_name=b'Date of death/closure (EDTF)', upper_fuzzy_field=b'end_date_sort_descending', natural_text_field=b'end_date_display', blank=True, lower_strict_field=b'end_date_earliest', help_text=b"an <a href='http://www.loc.gov/standards/datetime/implementations.html'>EDTF</a>-formatted date, parsed from the display date, e.g. '1855/1860-06-04'"),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='end_date_latest',
+            field=models.DateField(blank=True, verbose_name=b'Latest end date', null=True),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='end_date_sort_ascending',
+            field=models.DateField(blank=True, verbose_name=b'Ascending sort by end', null=True),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='end_date_sort_descending',
+            field=models.DateField(blank=True, verbose_name=b'Descending sort by end', null=True),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='start_date_display',
+            field=models.CharField(max_length=255, verbose_name=b'Date of birth/creation (display)', blank=True, help_text=b'Displays date as formatted for display, rather than sorting.'),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='start_date_earliest',
+            field=models.DateField(blank=True, verbose_name=b'Earliest start date', null=True),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='start_date_edtf',
+            field=edtf.fields.EDTFField(lower_fuzzy_field=b'start_date_sort_ascending', upper_strict_field=b'start_date_latest', null=True, verbose_name=b'Date of birth/creation (EDTF)', upper_fuzzy_field=b'start_date_sort_descending', natural_text_field=b'start_date_display', blank=True, lower_strict_field=b'start_date_earliest', help_text=b"an <a href='http://www.loc.gov/standards/datetime/implementations.html'>EDTF</a>-formatted date, parsed from the display date, e.g. '1855/1860-06-04'"),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='start_date_latest',
+            field=models.DateField(blank=True, verbose_name=b'Latest start date', null=True),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='start_date_sort_ascending',
+            field=models.DateField(blank=True, verbose_name=b'Ascending sort by start', null=True),
+        ),
+        migrations.AddField(
+            model_name='creatorbase',
+            name='start_date_sort_descending',
+            field=models.DateField(blank=True, verbose_name=b'Descending sort by start', null=True),
+        ),
+        migrations.AddField(
+            model_name='workbase',
+            name='creation_date_edtf',
+            field=edtf.fields.EDTFField(lower_fuzzy_field=b'creation_date_sort_ascending', upper_strict_field=b'creation_date_latest', null=True, verbose_name=b'Date of creation (EDTF)', upper_fuzzy_field=b'creation_date_sort_descending', natural_text_field=b'creation_date_display', blank=True, lower_strict_field=b'creation_date_earliest', help_text=b"an <a href='http://www.loc.gov/standards/datetime/implementations.html'>EDTF</a>-formatted date, parsed from the display date, e.g. '1855/1860-06-04'"),
+        ),
+    ]

--- a/glamkit_collections/contrib/work_creator/models.py
+++ b/glamkit_collections/contrib/work_creator/models.py
@@ -97,20 +97,24 @@ class CreatorBase(
     )
     wikipedia_link = models.URLField(blank=True, help_text="e.g. 'https://en.wikipedia.org/wiki/Pablo_Picasso'")
 
-    birth_date_display = models.CharField(
-        "Date of birth (display)",
+    ###########################################################################
+    # "Start" date common fields for person's birth and organisation's creation
+    ###########################################################################
+    start_date_display = models.CharField(
+        "Date of birth/creation (display)",
         blank=True,
         max_length=255,
         help_text='Displays date as formatted for display, rather '
                   'than sorting.'
     )
-    birth_date_edtf = EDTFField(
-        "Date of creation (EDTF)",
-        natural_text_field='birth_date_display',
-        lower_strict_field='birth_date_earliest',
-        upper_strict_field='birth_date_latest',
-        lower_fuzzy_field='birth_date_sort_ascending',
-        upper_fuzzy_field='birth_date_sort_descending',
+    start_date_edtf = EDTFField(
+        "Date of birth/creation (EDTF)",
+        natural_text_field='start_date_display',
+        # Use "start" date common fields from CreatorBase
+        lower_strict_field='start_date_earliest',
+        upper_strict_field='start_date_latest',
+        lower_fuzzy_field='start_date_sort_ascending',
+        upper_fuzzy_field='start_date_sort_descending',
         blank=True,
         null=True,
         help_text="an <a href='http://www.loc.gov/standards/datetime/"
@@ -118,41 +122,45 @@ class CreatorBase(
                   "date, parsed from the display date, e.g. "
                   "'1855/1860-06-04'",
     )
-    birth_date_earliest = models.DateField(
-        "Earliest birth date",
+    start_date_earliest = models.DateField(
+        "Earliest start date",
         blank=True,
         null=True,
     )
-    birth_date_latest = models.DateField(
-        "Latest birth date",
+    start_date_latest = models.DateField(
+        "Latest start date",
         blank=True,
         null=True,
     )
-    birth_date_sort_ascending = models.DateField(
-        "Ascending sort by birth",
+    start_date_sort_ascending = models.DateField(
+        "Ascending sort by start",
         blank=True,
         null=True,
     )
-    birth_date_sort_descending = models.DateField(
-        "Descending sort by birth",
+    start_date_sort_descending = models.DateField(
+        "Descending sort by start",
         blank=True,
         null=True,
     )
 
-    death_date_display = models.CharField(
-        "Date of death (display)",
+    ########################################################################
+    # "End" date common fields for person's death and organisation's closure
+    ########################################################################
+    end_date_display = models.CharField(
+        "Date of death/closure (display)",
         blank=True,
         max_length=255,
         help_text='Displays date as formatted for display, rather '
                   'than sorting.'
     )
-    death_date_edtf = EDTFField(
-        "Date of death (EDTF)",
-        natural_text_field='death_date_display',
-        lower_strict_field='death_date_earliest',
-        upper_strict_field='death_date_latest',
-        lower_fuzzy_field='death_date_sort_ascending',
-        upper_fuzzy_field='death_date_sort_descending',
+    end_date_edtf = EDTFField(
+        "Date of death/closure (EDTF)",
+        natural_text_field='end_date_display',
+        # Use "end" date common fields from CreatorBase
+        lower_strict_field='end_date_earliest',
+        upper_strict_field='end_date_latest',
+        lower_fuzzy_field='end_date_sort_ascending',
+        upper_fuzzy_field='end_date_sort_descending',
         blank=True,
         null=True,
         help_text="an <a href='http://www.loc.gov/standards/datetime/"
@@ -160,27 +168,26 @@ class CreatorBase(
                   "date, parsed from the display date, e.g. "
                   "'1855/1860-06-04'",
     )
-    death_date_earliest = models.DateField(
-        "Earliest death date",
+    end_date_earliest = models.DateField(
+        "Earliest end date",
         blank=True,
         null=True,
     )
-    death_date_latest = models.DateField(
-        "Latest death date",
+    end_date_latest = models.DateField(
+        "Latest end date",
         blank=True,
         null=True,
     )
-    death_date_sort_ascending = models.DateField(
-        "Ascending sort by death",
+    end_date_sort_ascending = models.DateField(
+        "Ascending sort by end",
         blank=True,
         null=True,
     )
-    death_date_sort_descending = models.DateField(
-        "Descending sort by death",
+    end_date_sort_descending = models.DateField(
+        "Descending sort by end",
         blank=True,
         null=True,
     )
-
 
     class Meta:
         verbose_name = "creator"
@@ -300,27 +307,27 @@ class WorkBase(
     )
     subtitle = models.CharField(max_length=511, blank=True)
     oneliner = models.CharField("One-liner", max_length=511, blank=True,
-                                 help_text="A pithy description of the work")
+                                help_text="A pithy description of the work")
 
     # who made it
     creators = models.ManyToManyField(
         'CreatorBase', through='WorkCreator', related_name='works'
     )
 
-    date_display = models.CharField(
+    creation_date_display = models.CharField(
         "Date of creation (display)",
         blank=True,
         max_length=255,
         help_text='Displays date as formatted for display, rather '
                   'than sorting.'
     )  # used on 'Explore Modern Art' 53841 records
-    date_edtf = EDTFField(
+    creation_date_edtf = EDTFField(
         "Date of creation (EDTF)",
-        natural_text_field='date_display',
-        lower_strict_field='date_earliest',
-        upper_strict_field='date_latest',
-        lower_fuzzy_field='date_sort_ascending',
-        upper_fuzzy_field='date_sort_descending',
+        natural_text_field='creation_date_display',
+        lower_strict_field='creation_date_earliest',
+        upper_strict_field='creation_date_latest',
+        lower_fuzzy_field='creation_date_sort_ascending',
+        upper_fuzzy_field='creation_date_sort_descending',
         blank=True,
         null=True,
         help_text="an <a href='http://www.loc.gov/standards/datetime/"
@@ -328,22 +335,22 @@ class WorkBase(
                   "date, parsed from the display date, e.g. "
                   "'1855/1860-06-04'",
     )
-    date_earliest = models.DateField(
+    creation_date_earliest = models.DateField(
         "Earliest date",
         blank=True,
         null=True,
     )
-    date_latest = models.DateField(
+    creation_date_latest = models.DateField(
         "Latest date",
         blank=True,
         null=True,
     )
-    date_sort_ascending = models.DateField(
+    creation_date_sort_ascending = models.DateField(
         "Ascending sort",
         blank=True,
         null=True,
     )
-    date_sort_descending = models.DateField(
+    creation_date_sort_descending = models.DateField(
         "Descending sort",
         blank=True,
         null=True,
@@ -388,8 +395,8 @@ class WorkBase(
         unique_together = ('slug', 'publishing_is_draft',)
 
     def __unicode__(self):
-        if self.date_display:
-            return u"%s (%s)" % (self.title, self.date_display)
+        if self.creation_date_display:
+            return u"%s (%s)" % (self.title, self.creation_date_display)
         return self.title
 
     def save(self, *args, **kwargs):
@@ -471,8 +478,8 @@ class WorkBase(
         return self.get_roles().filter(is_primary=True)
 
     def get_title(self):
-        if self.date_display:
-            return u"{0} ({1})".format(self.title, self.date_display)
+        if self.creation_date_display:
+            return u"{0} ({1})".format(self.title, self.creation_date_display)
         return self.title
 
     def get_origin_countries(self):

--- a/glamkit_collections/contrib/work_creator/plugins/organization/api.py
+++ b/glamkit_collections/contrib/work_creator/plugins/organization/api.py
@@ -13,12 +13,48 @@ VIEWNAME = 'api:organization-api'
 class Organization(Creator):
     type = serializers.SerializerMethodField()
     type_plural = serializers.SerializerMethodField()
+    # Rename start/end date creator fields to creation/closure for organization
+    creation_date_display = serializers.CharField(
+        source='start_date_display',
+        required=False,
+        allow_blank=True,
+    )
+    creation_date_edtf = serializers.CharField(
+        source='start_date_edtf',
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    closure_date_display = serializers.CharField(
+        source='end_date_display',
+        required=False,
+        allow_blank=True,
+    )
+    closure_date_edtf = serializers.CharField(
+        source='end_date_edtf',
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
 
     class Meta:
         model = OrganizationCreatorModel
-        fields = Creator.Meta.fields + (
+        # Use Creator field names except for those for start/end dates which we
+        # rename to creation/closure
+        _creator_fields = tuple(
+            f for f in Creator.Meta.fields
+            if (
+                not f.startswith('start_date_') and
+                not f.startswith('end_date_')
+            )
+        )
+        fields = _creator_fields + (
             'type',
             'type_plural',
+            'creation_date_display',
+            'creation_date_edtf',
+            'closure_date_display',
+            'closure_date_edtf',
         )
         extra_kwargs = dict(Creator.Meta.extra_kwargs, **{
             'url': {

--- a/glamkit_collections/contrib/work_creator/plugins/person/migrations/0003_auto_20170606_1158.py
+++ b/glamkit_collections/contrib/work_creator/plugins/person/migrations/0003_auto_20170606_1158.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gk_collections_person', '0002_remove_personcreator_name_full'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='personcreator',
+            old_name='life_info_birth_place',
+            new_name='birth_place',
+        ),
+        migrations.RenameField(
+            model_name='personcreator',
+            old_name='life_info_birth_place_historic',
+            new_name='birth_place_historic',
+        ),
+        migrations.RenameField(
+            model_name='personcreator',
+            old_name='life_info_death_place',
+            new_name='death_place',
+        ),
+        migrations.RemoveField(
+            model_name='personcreator',
+            name='life_info_birth_date_display',
+        ),
+        migrations.RemoveField(
+            model_name='personcreator',
+            name='life_info_birth_date_edtf',
+        ),
+        migrations.RemoveField(
+            model_name='personcreator',
+            name='life_info_death_date_display',
+        ),
+        migrations.RemoveField(
+            model_name='personcreator',
+            name='life_info_death_date_edtf',
+        ),
+    ]

--- a/glamkit_collections/contrib/work_creator/plugins/person/models.py
+++ b/glamkit_collections/contrib/work_creator/plugins/person/models.py
@@ -36,50 +36,18 @@ class PersonCreator(CreatorBase):
         max_length=255,
     )
 
-    life_info_birth_date_display = models.CharField(
-        blank=True,
-        max_length=255,
-        help_text='The display version of the creator\'s birth date, '
-                  'e.g. "circa August 1645"',
-        null=True
-    )
-    life_info_birth_date_edtf = models.CharField(
-        blank=True,
-        max_length=63,
-        help_text=
-            '<a href="http://www.loc.gov/standards/datetime/'
-            'implementations.html">EDTF</a>'
-            " version of the creator\'s birth date, as best as we could parse"
-            " from the display date e.g. \"1645-08~\""
-    )
-
-    life_info_birth_place = models.CharField(
+    birth_place = models.CharField(
         blank=True,
         max_length=255,
         help_text='The location of the creator\'s birth, e.g., "Utrecht"'
     )
-    life_info_birth_place_historic = models.CharField(
+    birth_place_historic = models.CharField(
         blank=True,
         max_length=255,
         help_text='The historical name of the place at the time of the '
                   'creator\'s birth, e.g., "Flanders"'
     )
-    life_info_death_date_display = models.CharField(
-        blank=True,
-        max_length=255,
-        help_text='The display version of the creator\'s death date, '
-                  'e.g., "before 1720s"',
-        null=True,
-    )
-    life_info_death_date_edtf = models.CharField(
-        blank=True,
-        max_length=63,
-        help_text=
-            '<a href="http://www.loc.gov/standards/datetime/'
-            'implementations.html">EDTF</a> '
-            'version of the creator\'s death date, e.g. \"[..172x]\"'
-    )
-    life_info_death_place = models.CharField(
+    death_place = models.CharField(
         blank=True,
         max_length=255,
         help_text='The location of the creator\'s death, e.g., "Antwerp."',
@@ -164,12 +132,12 @@ class PersonCreator(CreatorBase):
         n.d. - 1540s
         """
         birth = ", ".join(filter(None, (
-            self.life_info_birth_date_display,
-            self.life_info_birth_place
+            self.start_date_display,
+            self.start_place
         )))
         death = ", ".join(filter(None, (
-            self.life_info_death_date_display,
-            self.life_info_death_place
+            self.end_date_display,
+            self.end_place
         )))
 
         if death and not birth:


### PR DESCRIPTION
* `CreatorBase` now has generic names for start
  and end date fields to serve as the "birth"
  and "death" dates for persons, and "creation"
  and "closure" dates for organisations
* Rename `WorkBase.date_*` fields representing
  creation date to match: `creation_date_*`
* Remove redundant birth/death `life_info_*`
  fields from `PersonCreator
* Rename other `life_info_*` fields on
  `PersonCreator` to remove `life_info_` prefix
  for simplicity (there aren't that many of them
  any more)

Fields renamed or consolidated:

* Creator/Person/Organisation: `birth_date_*`
  => `start_date_*`
* Creator/Person/Organisation: `death_date_*`
  => `end_date_*`
* Artwork/Game/Film/MovingImage `date_*` =>
  `creation_date_*`
* Person: `life_info_birth_date_*` =>
  `start_date_*` (from `CreatorBase`)
* Person: `life_info_deat_date_*` =>
  `end_date_*` (from `CreatorBase`)
* Person: `life_info_birth_place` =>
  `birth_place`
* Person: `life_info_birth_place_historic`
  => `birth_place_historic`
* Person: `life_info_death_place` =>
  `death_place`

API Notes:

The API renames the `start_date_` and
`end_date_` fields from `CreatorBase` to
more appropriate model-specific names:
`birth_date_` & `death_date_` for persons,
`creation_date_` & `closure_date_` for
organizations.